### PR TITLE
Pre-install Sunup distributor for UnifiedPush

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -11,3 +11,6 @@ PRODUCT_PACKAGES += CustomCarProvision
 # We add the directBootAware attribute to the activity in the AndroidManifest.xml,
 # otherwise sometimes it wouldn't load and the system would be stuck on FallbackHome
 PRODUCT_PACKAGES += CustomCarLauncher
+
+# UnifiedPush distributor
+PRODUCT_PACKAGES += sunup


### PR DESCRIPTION
First version of integration into emulator.

The actual repo which will need to be referenced in the manifest is https://github.com/COVESA/aosp_vendor_covesa_sunup

TODO: something does not quite work yet, could it be that we are missing some permissions?

We have a test version of the emulator for ARM64 here: https://emulator.covesa.global/sdk/emulators/amm_15_05_test_sunup/